### PR TITLE
Feat/movimientos arka bajas traslados

### DIFF
--- a/database/files/20210212_095043_insertArkaBajasTraslados_down.sql
+++ b/database/files/20210212_095043_insertArkaBajasTraslados_down.sql
@@ -1,0 +1,4 @@
+DELETE FROM movimientos.tipo_movimiento WHERE acronimo = 'b_arka'
+AND EXISTS (SELECT 1 FROM movimientos.tipo_movimiento WHERE acronimo = 'b_arka');
+DELETE FROM movimientos.tipo_movimiento WHERE acronimo = 'tr_arka'
+AND EXISTS (SELECT 1 FROM movimientos.tipo_movimiento WHERE acronimo = 'tr_arka');

--- a/database/files/20210212_095043_insertArkaBajasTraslados_up.sql
+++ b/database/files/20210212_095043_insertArkaBajasTraslados_up.sql
@@ -1,3 +1,22 @@
+-- PARTE 1 - Resetear secuencia dañada por registros con IDs quemados
+-- Lo siguiente debería ser una forma segura de resetear el serial
+-- y permitir que de ahora en más no se admita quemar los IDs
+-- (o por lo menos para movimientos.tipo_movimiento)
+-- (Referencia: https://stackoverflow.com/a/244265/3180052)
+-- (Otra ref: https://hcmc.uvic.ca/blogs/index.php/how_to_fix_postgresql_error_duplicate_ke?blog=22)
+-- Equivale a (también funciona pero no es tan seguro):
+-- ALTER SEQUENCE movimientos.tipo_movimiento RESTART WITH 14
+-- Otras formas de alterar secuencias:
+-- https://stackoverflow.com/questions/8745051/postgres-manually-alter-sequence
+BEGIN;
+LOCK TABLE movimientos.tipo_movimiento IN EXCLUSIVE MODE;
+SELECT setval(
+    'movimientos.tipo_movimiento_id_seq',
+    COALESCE((SELECT MAX(id)+1 FROM movimientos.tipo_movimiento), 31),
+    false);
+COMMIT;
+
+-- PARTE 2 - Registros en sí
 INSERT INTO movimientos.tipo_movimiento (acronimo, nombre, descripcion, activo)
 VALUES
 ('b_arka', 'Baja', 'Baja de bienes y servicios de Arka II', true),

--- a/database/files/20210212_095043_insertArkaBajasTraslados_up.sql
+++ b/database/files/20210212_095043_insertArkaBajasTraslados_up.sql
@@ -1,0 +1,4 @@
+INSERT INTO movimientos.tipo_movimiento (acronimo, nombre, descripcion, activo)
+VALUES
+('b_arka', 'Baja', 'Baja de bienes y servicios de Arka II', true),
+('tr_arka', 'Traslado', 'Traslado de bienes y servicios de Arka II',  true);

--- a/database/migrations/20210128_114137_insert_entrada_desarrollo_intangible.go
+++ b/database/migrations/20210128_114137_insert_entrada_desarrollo_intangible.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/astaxie/beego/client/orm/migration"
+	"github.com/astaxie/beego/migration"
 )
 
 // DO NOT MODIFY

--- a/database/migrations/20210212_095043_insertArkaBajasTraslados.go
+++ b/database/migrations/20210212_095043_insertArkaBajasTraslados.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/astaxie/beego/migration"
+)
+
+// DO NOT MODIFY
+type InsertArkaBajasTraslados_20210212_095043 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &InsertArkaBajasTraslados_20210212_095043{}
+	m.Created = "20210212_095043"
+
+	migration.Register("InsertArkaBajasTraslados_20210212_095043", m)
+}
+
+// Run the migrations
+func (m *InsertArkaBajasTraslados_20210212_095043) Up() {
+
+	file, err := ioutil.ReadFile("../files/20210212_095043_insertArkaBajasTraslados_up.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+	}
+
+}
+
+// Reverse the migrations
+func (m *InsertArkaBajasTraslados_20210212_095043) Down() {
+
+	file, err := ioutil.ReadFile("../files/20210212_095043_insertArkaBajasTraslados_down.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+	}
+
+}


### PR DESCRIPTION
Relacionado con udistrital/arka_cliente#482

Los registros nuevos se agregaron en aa9931e y 258ae99, acorde al [lineamiento de migraciones](https://github.com/udistrital/lineamientos_oas/blob/master/generacion_de_apis/beego_migrations.md)

Lo demás commit son fix que fueron necesarios para realizar las migraciones e insertar los registros sin quemar los IDs (se reestablece el índice, de manera similar a udistrital/movimientos_arka_crud#29 )