### PR TITLE
fix: migracion fallida (ver mensaje del commit-->)

### DIFF
--- a/database/files/20210212_095043_insertArkaBajasTraslados_up.sql
+++ b/database/files/20210212_095043_insertArkaBajasTraslados_up.sql
@@ -1,22 +1,3 @@
--- PARTE 1 - Resetear secuencia dañada por registros con IDs quemados
--- Lo siguiente debería ser una forma segura de resetear el serial
--- y permitir que de ahora en más no se admita quemar los IDs
--- (o por lo menos para movimientos.tipo_movimiento)
--- (Referencia: https://stackoverflow.com/a/244265/3180052)
--- (Otra ref: https://hcmc.uvic.ca/blogs/index.php/how_to_fix_postgresql_error_duplicate_ke?blog=22)
--- Equivale a (también funciona pero no es tan seguro):
--- ALTER SEQUENCE movimientos.tipo_movimiento RESTART WITH 14
--- Otras formas de alterar secuencias:
--- https://stackoverflow.com/questions/8745051/postgres-manually-alter-sequence
-BEGIN;
-LOCK TABLE movimientos.tipo_movimiento IN EXCLUSIVE MODE;
-SELECT setval(
-    'movimientos.tipo_movimiento_id_seq',
-    COALESCE((SELECT MAX(id)+1 FROM movimientos.tipo_movimiento), 31),
-    false);
-COMMIT;
-
--- PARTE 2 - Registros en sí
 INSERT INTO movimientos.tipo_movimiento (acronimo, nombre, descripcion, activo)
 VALUES
 ('b_arka', 'Baja', 'Baja de bienes y servicios de Arka II', true),

--- a/database/files/insert_tipomovimiento_desarrollo_intangible.up.sql
+++ b/database/files/insert_tipomovimiento_desarrollo_intangible.up.sql
@@ -1,1 +1,22 @@
-INSERT INTO movimientos.tipo_movimiento (id, nombre, descripcion, acronimo, activo)VALUES (30, 'Desarrollo interior', 'Entrada Intangibles Desarrollados al interior de los entes', 'e_arka', true);
+-- PARTE 1 - Resetear secuencia dañada por registros con IDs quemados
+-- Lo siguiente debería ser una forma segura de resetear el serial
+-- y permitir que de ahora en más no se admita quemar los IDs
+-- (o por lo menos para movimientos.tipo_movimiento)
+-- (Referencia: https://stackoverflow.com/a/244265/3180052)
+-- (Otra ref: https://hcmc.uvic.ca/blogs/index.php/how_to_fix_postgresql_error_duplicate_ke?blog=22)
+-- Equivale a (también funciona pero no es tan seguro):
+-- ALTER SEQUENCE movimientos.tipo_movimiento RESTART WITH 14
+-- Otras formas de alterar secuencias:
+-- https://stackoverflow.com/questions/8745051/postgres-manually-alter-sequence
+BEGIN;
+LOCK TABLE movimientos.tipo_movimiento IN EXCLUSIVE MODE;
+SELECT setval(
+    'movimientos.tipo_movimiento_id_seq',
+    COALESCE((SELECT MAX(id)+1 FROM movimientos.tipo_movimiento), 30),
+    false);
+COMMIT;
+
+-- PARTE 2 - Registros en sí
+INSERT INTO movimientos.tipo_movimiento (nombre, descripcion, acronimo, activo)
+VALUES
+('Desarrollo interior', 'Entrada Intangibles Desarrollados al interior de los entes', 'e_arka', true);


### PR DESCRIPTION
Falló la compilación
https://hubci.portaloas.udistrital.edu.co/udistrital/movimientos_crud/110/1/8

De acuerdo a lo anterior, falló la migración `InsertEntradaDesarrolloIntangible_20210128_114137` (#79)

Para arreglarla, se movió la restauración del índice de la tabla `tipo_movimiento` una migración atras:

Antes en 20210212_095043_insertArkaBajasTraslados_up.sql (407786bb - #87)
Ahora en insert_tipomovimiento_desarrollo_intangible.up.sql (02011e92 - #79)